### PR TITLE
Clean up test assertions

### DIFF
--- a/src/actdiag/tests/test_rst_directives.py
+++ b/src/actdiag/tests/test_rst_directives.py
@@ -47,11 +47,11 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(directives.ActdiagDirective,
                          docutils._directives['actdiag'])
         self.assertEqual('PNG', options['format'])
-        self.assertEqual(False, options['antialias'])
-        self.assertEqual(None, options['fontpath'])
-        self.assertEqual(False, options['nodoctype'])
-        self.assertEqual(False, options['noviewbox'])
-        self.assertEqual(False, options['inline_svg'])
+        self.assertFalse(options['antialias'])
+        self.assertIsNone(options['fontpath'])
+        self.assertFalse(options['nodoctype'])
+        self.assertFalse(options['noviewbox'])
+        self.assertFalse(options['inline_svg'])
 
     def test_setup_with_args(self):
         directives.setup(format='SVG', antialias=True, fontpath='/dev/null',
@@ -62,11 +62,11 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(directives.ActdiagDirective,
                          docutils._directives['actdiag'])
         self.assertEqual('SVG', options['format'])
-        self.assertEqual(True, options['antialias'])
+        self.assertTrue(options['antialias'])
         self.assertEqual('/dev/null', options['fontpath'])
-        self.assertEqual(True, options['nodoctype'])
-        self.assertEqual(True, options['noviewbox'])
-        self.assertEqual(True, options['inline_svg'])
+        self.assertTrue(options['nodoctype'])
+        self.assertTrue(options['noviewbox'])
+        self.assertTrue(options['inline_svg'])
 
     @capture_stderr
     def test_cleanup(self):
@@ -131,7 +131,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, r'<svg height="\d+" width="\d+" ')
+        self.assertRegex(svg, r'<svg height="\d+" width="\d+" ')
 
     def test_setup_noviewbox_is_false(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, noviewbox=False)
@@ -142,7 +142,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, r'<svg viewBox="0 0 \d+ \d+" ')
+        self.assertRegex(svg, r'<svg viewBox="0 0 \d+ \d+" ')
 
     def test_setup_inline_svg_is_true(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, inline_svg=True)
@@ -189,8 +189,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
-                                 r'<svg height="\d+" width="100" ')
+        self.assertRegex(doctree[0][0], r'<svg height="\d+" width="100" ')
 
     def test_setup_inline_svg_is_true_and_width_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -203,8 +202,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
-                                 r'<svg height="\d+" width="10000" ')
+        self.assertRegex(doctree[0][0], r'<svg height="\d+" width="10000" ')
 
     def test_setup_inline_svg_is_true_and_height_option1(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -217,8 +215,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
-                                 r'<svg height="100" width="\d+" ')
+        self.assertRegex(doctree[0][0], r'<svg height="100" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_height_option2(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -231,8 +228,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
-                                 r'<svg height="10000" width="\d+" ')
+        self.assertRegex(doctree[0][0], r'<svg height="10000" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_width_and_height_option(self):
         directives.setup(format='SVG', outputdir=self.tmpdir,
@@ -246,8 +242,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
-                                 '<svg height="100" width="200" ')
+        self.assertRegex(doctree[0][0], '<svg height="100" width="200" ')
 
     def test_call_with_braces(self):
         directives.setup(format='SVG', outputdir=self.tmpdir)


### PR DESCRIPTION
Python 3.1 and 3.2 massively cleaned up and reorganized assert* methods in TestCase, all for the better. A large amount of methods were then deprecated, and they have finally been removed in Python 3.12. Clean up the callsites.