### PR TITLE
assertRegexpMatches has been replaced with assertRegex from python-3.2

### DIFF
--- a/src/actdiag/tests/test_rst_directives.py
+++ b/src/actdiag/tests/test_rst_directives.py
@@ -131,7 +131,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, r'<svg height="\d+" width="\d+" ')
+        self.assertRegex(svg, r'<svg height="\d+" width="\d+" ')
 
     def test_setup_noviewbox_is_false(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, noviewbox=False)
@@ -142,7 +142,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.image, type(doctree[0]))
         svg = open(doctree[0]['uri']).read()
-        self.assertRegexpMatches(svg, r'<svg viewBox="0 0 \d+ \d+" ')
+        self.assertRegex(svg, r'<svg viewBox="0 0 \d+ \d+" ')
 
     def test_setup_inline_svg_is_true(self):
         directives.setup(format='SVG', outputdir=self.tmpdir, inline_svg=True)
@@ -189,7 +189,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
+        self.assertRegex(doctree[0][0],
                                  r'<svg height="\d+" width="100" ')
 
     def test_setup_inline_svg_is_true_and_width_option2(self):
@@ -203,7 +203,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
+        self.assertRegex(doctree[0][0],
                                  r'<svg height="\d+" width="10000" ')
 
     def test_setup_inline_svg_is_true_and_height_option1(self):
@@ -217,7 +217,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
+        self.assertRegex(doctree[0][0],
                                  r'<svg height="100" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_height_option2(self):
@@ -231,7 +231,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
+        self.assertRegex(doctree[0][0],
                                  r'<svg height="10000" width="\d+" ')
 
     def test_setup_inline_svg_is_true_and_width_and_height_option(self):
@@ -246,7 +246,7 @@ class TestRstDirectives(unittest.TestCase):
         self.assertEqual(1, len(doctree))
         self.assertEqual(nodes.raw, type(doctree[0]))
         self.assertEqual(nodes.Text, type(doctree[0][0]))
-        self.assertRegexpMatches(doctree[0][0],
+        self.assertRegex(doctree[0][0],
                                  '<svg height="100" width="200" ')
 
     def test_call_with_braces(self):


### PR DESCRIPTION
https://cainiaojiaocheng.com/Python/docs/3.7/library/unittest#unittest.TestCase.assertRegex